### PR TITLE
appengine: Update .gcloudignore so only the build folder is deployed for client

### DIFF
--- a/client/.gcloudignore
+++ b/client/.gcloudignore
@@ -1,5 +1,5 @@
-# Exclude compiled .js files
-# *.js
+# Ignore everything
+/**
 
-# Exclude dependencies
-node_modules/
+# Except the built react app
+!build/**


### PR DESCRIPTION
Should also speed up deployments since fewer files will be uploaded.